### PR TITLE
Updated pyproject.toml  with dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "tickertock"
 description = "Streamdeck as a timetracker"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.7, <3.11"
 keywords = ["timetracking", "clockify"]
 license = {text = "MIT License"}
 classifiers = [
@@ -18,7 +18,7 @@ dependencies = [
     "jinja2",
     "filetype",
     "toml",
-    "PySide2",
+    "PySide6",
     "clockify",
     "click",
     "xdg",


### PR DESCRIPTION
Updated pyproject.toml with pyside6 required dep
Having issue with python3.12 relating to hidapi similar to - [Issue: 64728](https://github.com/zephyrproject-rtos/zephyr/issues/64728) 


`
@AhmedHaisaraQuasar Thanks for taking the time to report the issue, and sorry that you had trouble with the recently released version of Python 3.12. Unfortunately some binary packages are not available from pypi and make for a troublesome install experience. As stated by @nordicjm, please use Python 3.11 for now.
`